### PR TITLE
[feature/server_cd] chore: server cd workflow 수정

### DIFF
--- a/.github/workflows/server-CD.yml
+++ b/.github/workflows/server-CD.yml
@@ -22,13 +22,9 @@ jobs:
             export DATABASE_USERNAME=${{ secrets.DATABASE_USERNAME }}
             export DATABASE_PASSWORD=${{ secrets.DATABASE_PASSWORD }}
 
-            export GITHUB_CLIENT_ID=${{ secrets.OAUTH_CLIENT_ID }}
-            export GITHUB_CLIENT_SECRET=${{ secrets.OAUTH_CLIENT_SECRET }}
-
             cd ~/Tenta
             git checkout develop
             git pull origin develop
 
             cd tenta-server
-            chmod +x gradlew
             ./gradlew build


### PR DESCRIPTION
# 구현내용
- build하는데에 github oauth 설정이 필요가 없어서 뺐습니다.
- gradlew 실행 권한을 주면 파일해쉬값이 달라져서 unstaging 상태가 됩니다. 
  다음 pr merge이후 unstaging 파일이있어서 pull명령어에서 err가 발생하여 제거합니다. 
  그래서 이전 커밋에서 실행 권한을 준 gradlew 파일을 커밋해 두었습니다.
